### PR TITLE
Added build possibility to the worker automatic config generator

### DIFF
--- a/scripts/generate_workers_cfg.sh
+++ b/scripts/generate_workers_cfg.sh
@@ -77,7 +77,13 @@ generate_workers () {
               add_section_with_value network_mode host
             fi
 
-            add_section_with_value image $(_jq '.image')
+            if [ $(_jq '.image') != null ]; then
+              add_section_with_value image $(_jq '.image')
+            elif [ $(_jq '.build') != null ]; then
+              add_section_with_value build $(_jq '.build')
+            else
+              echo "WARNING : No image nor build were given !"
+            fi
 
             if [ $(_jq '.gpu') = "true" ]; then
                 add_section_with_value runtime nvidia


### PR DESCRIPTION
Added the possibility to choose build in the *.workers config files instead of image for development purposes. 
- Modified the `generate_workers_config.sh` to take into account the `build` key.
- Added a warning message if neither image nor build key was passed.