### PR TITLE
Fix/worker amqp vhost

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -16,6 +16,9 @@ AMQP_PORT=5672
 AMQP_MANAGEMENT_PORT=15672
 AMQP_USERNAME=mediacloudai
 AMQP_PASSWORD=mediacloudai
+# AMQP_VHOST is deprecated for backend but always used by workers. Will be deprecated soon.
+AMQP_VHOST=media_cloud_ai_dev
+# AMQP_VIRTUAL_HOST is used by backend.
 AMQP_VIRTUAL_HOST=media_cloud_ai_dev
 AMQP_TLS=false
 

--- a/opensource.workers
+++ b/opensource.workers
@@ -1,9 +1,9 @@
 [
 	{
-                "name": "transfer_optim",
-                "image": "mediacloudai/aws_cli_worker:v0.1.0",
-                "count": 1,
-                "vault": false
+        "name": "aws_cli",
+        "image": "mediacloudai/aws_cli_worker:v0.1.0",
+        "count": 1,
+        "vault": false
 	},
 	{
 		"name": "file_system",

--- a/opensource.workers
+++ b/opensource.workers
@@ -1,5 +1,11 @@
 [
 	{
+                "name": "transfer_optim",
+                "image": "mediacloudai/aws_cli_worker:v0.1.0",
+                "count": 1,
+                "vault": false
+	},
+	{
 		"name": "file_system",
 		"image": "mediacloudai/rs_file_system_worker:v1.2.0",
 		"count": 1,

--- a/scripts/generate_workers_cfg.sh
+++ b/scripts/generate_workers_cfg.sh
@@ -109,7 +109,13 @@ generate_workers () {
             add_env_var AMQP_MANAGEMENT_PORT
             add_env_var AMQP_USERNAME
             add_env_var AMQP_PASSWORD
-            add_env_var AMQP_VIRTUAL_HOST
+            if [ ! -z "${AMQP_VIRTUAL_HOST}" ]; then
+              add_env_var AMQP_VIRTUAL_HOST
+            fi
+            # AMQP_VHOST will be deprecated soon.
+            if [ ! -z "${AMQP_VHOST}" ]; then
+              add_env_var AMQP_VHOST
+            fi
             add_env_var AMQP_TLS
 
             if [ `echo ${row} | base64 --decode | jq '.environment!=null'` == true ]; then


### PR DESCRIPTION
AMQP_VHOST was removed from configuration in .env.dist because ex_backend now use AMQP_VIRTUAL_HOST.
But, for now, workers are still using AMQP_VHOST because the AMQP library has not yet been updated. So, to work, AMQP_VHOST must be reintegrated into the configuration and the two variables must coexist.